### PR TITLE
Add support for linting while typing

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,23 @@
         "command": "crystal.ameba.disable",
         "title": "Crystal Ameba: disable lints (workspace)"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Crystal Ameba configuration",
+      "properties": {
+        "crystal-ameba.lint-trigger": {
+          "type": "string",
+          "description": "When the linter should be executed. Set to `none` to disable automatic linting.",
+          "default": "type",
+          "enum": [
+            "none",
+            "save",
+            "type"
+          ]
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run compile",
@@ -55,8 +71,12 @@
     "@types/mocha": "^10.0.9",
     "@types/node": "^22.9.0",
     "@types/vscode": "^1.75.0",
+    "@types/semver": "^7.5.8",
     "tslint": "^6.1.3",
     "typescript": "^5.6.3",
     "vscode-test": "^1.6.1"
+  },
+  "dependencies": {
+    "semver": "^7.6.3"
   }
 }

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -40,7 +40,8 @@ export class Ameba {
         if (!virtual) {
             args.push(document.fileName)
         } else {
-            args.push('--stdin-filename', document.fileName);
+            // Indicate that the source is passed through STDIN
+            args.push('-');
 
             // Disabling these as they're common when typing
             args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace,Naming/Filename');
@@ -164,7 +165,9 @@ export class Ameba {
                         }
 
                         let diagnosticUri: Uri;
-                        if (path.isAbsolute(source.path)) {
+                        if (virtual) {
+                            diagnosticUri = document.uri;
+                        } else if (path.isAbsolute(source.path)) {
                             diagnosticUri = Uri.parse(source.path)
                         } else if (document.isUntitled) {
                             diagnosticUri = document.uri;

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -16,7 +16,7 @@ import {
 import { AmebaOutput } from './amebaOutput';
 import { AmebaConfig, getConfig } from './configuration';
 import { Task, TaskQueue } from './taskQueue';
-import { isDocumentVirtual, noWorkspaceFolder, outputChannel } from './extension';
+import { isCrystalDocument, isDocumentVirtual, noWorkspaceFolder, outputChannel } from './extension';
 
 export class Ameba {
     private diag: DiagnosticCollection;

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -40,11 +40,11 @@ export class Ameba {
         if (!virtual) {
             args.push(document.fileName)
         } else {
-            // Indicate that the source is passed through STDIN
-            args.push('-');
-
             // Disabling these as they're common when typing
             args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace');
+
+            // Indicate that the source is passed through STDIN
+            args.push('-');
         }
 
         const configFile = path.join(dir, this.config.configFileName);

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -30,7 +30,7 @@ export class Ameba {
     }
 
     public execute(document: TextDocument, virtual: boolean = false): void {
-        if (document.languageId !== 'crystal') return;
+        if (!isCrystalDocument(document)) return;
         if (isDocumentVirtual(document) && !virtual) return;
 
         const dir = (workspace.getWorkspaceFolder(document.uri) ?? noWorkspaceFolder(document.uri)).uri.fsPath;

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -44,7 +44,7 @@ export class Ameba {
             args.push('-');
 
             // Disabling these as they're common when typing
-            args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace,Naming/Filename');
+            args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace');
         }
 
         const configFile = path.join(dir, this.config.configFileName);
@@ -169,8 +169,6 @@ export class Ameba {
                             diagnosticUri = document.uri;
                         } else if (path.isAbsolute(source.path)) {
                             diagnosticUri = Uri.parse(source.path)
-                        } else if (document.isUntitled) {
-                            diagnosticUri = document.uri;
                         } else {
                             diagnosticUri = Uri.parse(path.join(dir, source.path));
                         }

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -16,7 +16,7 @@ import {
 import { AmebaOutput } from './amebaOutput';
 import { AmebaConfig, getConfig } from './configuration';
 import { Task, TaskQueue } from './taskQueue';
-import { outputChannel } from './extension';
+import { isDocumentVirtual, noWorkspaceFolder, outputChannel } from './extension';
 
 export class Ameba {
     private diag: DiagnosticCollection;
@@ -29,13 +29,23 @@ export class Ameba {
         this.config = getConfig();
     }
 
-    public execute(document: TextDocument): void {
-        if (document.languageId !== 'crystal' || document.isUntitled || document.uri.scheme !== 'file') {
-            return;
+    public execute(document: TextDocument, virtual: boolean = false): void {
+        if (document.languageId !== 'crystal') return;
+        if (isDocumentVirtual(document) && !virtual) return;
+
+        const dir = (workspace.getWorkspaceFolder(document.uri) ?? noWorkspaceFolder(document.uri)).uri.fsPath;
+
+        const args = [this.config.command, '--format', 'json'];
+
+        if (!virtual) {
+            args.push(document.fileName)
+        } else {
+            args.push('--stdin-filename', document.fileName);
+
+            // Disabling these as they're common when typing
+            args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace,Naming/Filename');
         }
 
-        const args = [this.config.command, document.fileName, '--format', 'json'];
-        const dir = workspace.getWorkspaceFolder(document.uri)!.uri.fsPath;
         const configFile = path.join(dir, this.config.configFileName);
         if (existsSync(configFile)) args.push('--config', configFile);
 
@@ -46,6 +56,12 @@ export class Ameba {
 
                 outputChannel.appendLine(`$ ${args.join(' ')}`)
                 const proc = spawn(args[0], args.slice(1), { cwd: dir });
+
+                if (virtual) {
+                    const documentText: string = document.getText();
+                    proc.stdin.write(documentText)
+                    proc.stdin.end();
+                }
 
                 token.onCancellationRequested(_ => {
                     proc.kill();

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -6,7 +6,6 @@ import { execSync } from 'child_process';
 
 import { outputChannel } from './extension';
 
-
 export interface AmebaConfig {
     command: string;
     configFileName: string;

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -1,11 +1,22 @@
 import { workspace } from 'vscode';
 import * as path from 'path';
 import { existsSync } from 'fs';
+import * as semver from 'semver';
+import { execSync } from 'child_process';
+
+import { outputChannel } from './extension';
+
 
 export interface AmebaConfig {
     command: string;
     configFileName: string;
-    onSave: boolean;
+    trigger: LintTrigger;
+}
+
+export enum LintTrigger {
+    None = "none",
+    Save = "save",
+    Type = "type"
 }
 
 export function getConfig(): AmebaConfig {
@@ -13,12 +24,26 @@ export function getConfig(): AmebaConfig {
     const root = workspace.workspaceFolders || [];
     if (root.length) {
         const localAmebaPath = path.join(root[0].uri.fsPath, 'bin', 'ameba');
-        if (existsSync(localAmebaPath)) command = localAmebaPath;
+        if (existsSync(localAmebaPath)) {
+            outputChannel.appendLine(`[Config] Using local ameba at ${localAmebaPath}`)
+            command = localAmebaPath;
+        } else {
+            outputChannel.appendLine(`[Config] Using system ameba`)
+        }
+    }
+
+    const workspaceConfig = workspace.getConfiguration('crystal-ameba');
+    const currentVersion = execSync(`"${command}" --version`).toString();
+
+    let trigger = workspaceConfig.get<LintTrigger>("lint-trigger", LintTrigger.Type);
+
+    if (!semver.satisfies(currentVersion, ">=1.6.4") && trigger == LintTrigger.Type) {
+        trigger = LintTrigger.Save;
     }
 
     return {
         command,
         configFileName: '.ameba.yml',
-        onSave: true
+        trigger: trigger
     };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,7 @@ export function activate(context: ExtensionContext) {
 
     // This can happen when a file is open _or_ when a file's language id changes
     workspace.onDidOpenTextDocument(doc => {
-        if (ameba && doc.languageId === 'crystal') {
+        if (ameba && doc.languageId === 'crystal' && ameba.config.trigger !== LintTrigger.None) {
             if (isDocumentVirtual(doc)) {
                 if (ameba.config.trigger === LintTrigger.Type) {
                     outputChannel.appendLine(`[Open] Running ameba on ${getRelativePath(doc)}`);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
 import * as path from 'path'
 
 import { Ameba } from './ameba';
-import { getConfig } from './configuration';
+import { getConfig, LintTrigger } from './configuration';
 
 
 export let outputChannel: OutputChannel;
@@ -18,6 +18,7 @@ export function activate(context: ExtensionContext) {
 
     const diag = languages.createDiagnosticCollection('crystal');
     let ameba: Ameba | null = new Ameba(diag);
+
     context.subscriptions.push(diag);
 
     context.subscriptions.push(
@@ -83,12 +84,30 @@ export function activate(context: ExtensionContext) {
 
     executeAmebaOnWorkspace(ameba);
 
+    // This can happen when a file is open _or_ when a file's language id changes
     workspace.onDidOpenTextDocument(doc => {
-        ameba && ameba.execute(doc);
+        if (ameba && doc.languageId === 'crystal') {
+            if (isDocumentVirtual(doc)) {
+                if (ameba.config.trigger === LintTrigger.Type) {
+                    outputChannel.appendLine(`[Open] Running ameba on ${getRelativePath(doc)}`);
+                    ameba.execute(doc, true);
+                }
+            } else {
+                outputChannel.appendLine(`[Open] Running ameba on ${getRelativePath(doc)}`);
+                ameba.execute(doc);
+            }
+        }
     });
 
+    workspace.onDidChangeTextDocument(e => {
+        if (ameba && ameba.config.trigger == LintTrigger.Type && e.document.languageId === 'crystal') {
+            outputChannel.appendLine(`[Change] Running ameba on ${getRelativePath(e.document)}`);
+            ameba.execute(e.document, true);
+        }
+    })
+
     workspace.onDidSaveTextDocument(doc => {
-        if (ameba && ameba.config.onSave && isValidCrystalDocument(doc)) {
+        if (ameba && ameba.config.trigger === LintTrigger.Save && isValidCrystalDocument(doc)) {
             outputChannel.appendLine(`[Save] Running ameba on ${getRelativePath(doc)}`)
             ameba.execute(doc);
         } else if (ameba && path.basename(doc.fileName) == ".ameba.yml") {
@@ -132,4 +151,8 @@ export function noWorkspaceFolder(uri: Uri): WorkspaceFolder {
 
 function isValidCrystalDocument(doc: TextDocument): boolean {
     return doc.languageId === 'crystal' && !doc.isUntitled && doc.uri.scheme === 'file'
+}
+
+export function isDocumentVirtual(document: TextDocument): boolean {
+    return document.isDirty || document.isUntitled || document.uri.scheme !== 'file'
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -149,8 +149,8 @@ export function noWorkspaceFolder(uri: Uri): WorkspaceFolder {
     }
 }
 
-function isValidCrystalDocument(doc: TextDocument): boolean {
-    return doc.languageId === 'crystal' && !doc.isUntitled && doc.uri.scheme === 'file'
+function isCrystalDocument(doc: TextDocument): boolean {
+    return doc.languageId === 'crystal'
 }
 
 export function isDocumentVirtual(document: TextDocument): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,7 @@ export function activate(context: ExtensionContext) {
 export function deactivate() { }
 
 function executeAmebaOnWorkspace(ameba: Ameba | null) {
-    if (!ameba) return;
+    if (!ameba || ameba.config.trigger === LintTrigger.None) return;
 
     for (const doc of workspace.textDocuments) {
         if (isCrystalDocument(doc)) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -100,7 +100,7 @@ export function activate(context: ExtensionContext) {
     });
 
     workspace.onDidChangeTextDocument(e => {
-        if (ameba && ameba.config.trigger == LintTrigger.Type && e.document.languageId === 'crystal') {
+        if (ameba && ameba.config.trigger == LintTrigger.Type && isCrystalDocument(e.document)) {
             outputChannel.appendLine(`[Change] Running ameba on ${getRelativePath(e.document)}`);
             ameba.execute(e.document, true);
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -107,7 +107,7 @@ export function activate(context: ExtensionContext) {
     })
 
     workspace.onDidSaveTextDocument(doc => {
-        if (ameba && ameba.config.trigger === LintTrigger.Save && isValidCrystalDocument(doc)) {
+        if (ameba && ameba.config.trigger === LintTrigger.Save && isCrystalDocument(doc)) {
             outputChannel.appendLine(`[Save] Running ameba on ${getRelativePath(doc)}`)
             ameba.execute(doc);
         } else if (ameba && path.basename(doc.fileName) == ".ameba.yml") {
@@ -128,7 +128,7 @@ function executeAmebaOnWorkspace(ameba: Ameba | null) {
     if (!ameba) return;
 
     for (const doc of workspace.textDocuments) {
-        if (isValidCrystalDocument(doc)) {
+        if (isCrystalDocument(doc)) {
             outputChannel.appendLine(`[Workspace] Running ameba on ${getRelativePath(doc)}`);
             ameba.execute(doc);
         }
@@ -149,7 +149,7 @@ export function noWorkspaceFolder(uri: Uri): WorkspaceFolder {
     }
 }
 
-function isCrystalDocument(doc: TextDocument): boolean {
+export function isCrystalDocument(doc: TextDocument): boolean {
     return doc.languageId === 'crystal'
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -86,7 +86,7 @@ export function activate(context: ExtensionContext) {
 
     // This can happen when a file is open _or_ when a file's language id changes
     workspace.onDidOpenTextDocument(doc => {
-        if (ameba && doc.languageId === 'crystal' && ameba.config.trigger !== LintTrigger.None) {
+        if (ameba && ameba.config.trigger !== LintTrigger.None && isCrystalDocument(doc)) {
             if (isDocumentVirtual(doc)) {
                 if (ameba.config.trigger === LintTrigger.Type) {
                     outputChannel.appendLine(`[Open] Running ameba on ${getRelativePath(doc)}`);


### PR DESCRIPTION
- Adds settings `crystal-ameba.lint-trigger`:
  - `none`: linting will always be triggered automatically by commands
  - `save`: linting is only triggered when saving
  - `type`: linting is run for the current file every time there's a change
- Defaults to `type` unless ameba is < 1.6.4

Resolves #89 