### PR TITLE
Add `lint-scope` config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,12 +42,25 @@
       {
         "command": "crystal.ameba.disable",
         "title": "Crystal Ameba: disable lints (workspace)"
+      },
+      {
+        "command": "crystal.ameba.lint-workspace",
+        "title": "Crystal Ameba: lint all files in workspace"
       }
     ],
     "configuration": {
       "type": "object",
       "title": "Crystal Ameba configuration",
       "properties": {
+        "crystal-ameba.lint-scope": {
+          "type": "string",
+          "description": "Whether the linter should only care about open files or all files in the workspace.",
+          "default": "file",
+          "enum": [
+            "file",
+            "workspace"
+          ]
+        },
         "crystal-ameba.lint-trigger": {
           "type": "string",
           "description": "When the linter should be executed. Set to `none` to disable automatic linting.",

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -10,7 +10,8 @@ import {
     TextDocument,
     Uri,
     window,
-    workspace
+    workspace,
+    WorkspaceFolder
 } from 'vscode';
 
 import { AmebaOutput } from './amebaOutput';
@@ -29,9 +30,14 @@ export class Ameba {
         this.config = getConfig();
     }
 
-    public execute(document: TextDocument, virtual: boolean = false): void {
-        if (!isValidCrystalDocument(document)) return;
-        if (isDocumentVirtual(document) && !virtual) return;
+    public execute(document: TextDocument | WorkspaceFolder, virtual: boolean = false): void {
+        const isWorkspace = !('languageId' in document);
+        if (isWorkspace) virtual = false;
+
+        if (!isWorkspace) {
+            if (!isValidCrystalDocument(document)) return;
+            if (isDocumentVirtual(document) && !virtual) return;
+        }
 
         const dir = (workspace.getWorkspaceFolder(document.uri) ?? noWorkspaceFolder(document.uri)).uri.fsPath;
 
@@ -39,18 +45,20 @@ export class Ameba {
         const configFile = path.join(dir, this.config.configFileName);
         if (existsSync(configFile)) args.push('--config', configFile);
 
-        if (!virtual) {
-            args.push(document.fileName)
-        } else {
-            // Disabling these as they're common when typing
-            args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace');
-
-            // Indicate that the source is passed through STDIN
-            if (document.uri.scheme === 'untitled') {
-                args.push('-')
+        if (!isWorkspace) {
+            if (!virtual) {
+                args.push(document.fileName)
             } else {
-                // Necessary to support excludes in ameba config
-                args.push('--stdin-filename', document.fileName);
+                // Disabling these as they're common when typing
+                args.push('--except', 'Lint/Formatting,Layout/TrailingBlankLines,Layout/TrailingWhitespace');
+
+                // Indicate that the source is passed through STDIN
+                if (document.uri.scheme === 'untitled') {
+                    args.push('-')
+                } else {
+                    // Necessary to support excludes in ameba config
+                    args.push('--stdin-filename', document.fileName);
+                }
             }
         }
 
@@ -63,7 +71,7 @@ export class Ameba {
                 outputChannel.appendLine(`$ ${args.join(' ')}`)
                 const proc = spawn(args[0], args.slice(1), { cwd: dir });
 
-                if (virtual) {
+                if (virtual && !isWorkspace) {
                     const documentText: string = document.getText();
                     proc.stdin.write(documentText)
                     proc.stdin.end();

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -31,11 +31,9 @@ export class Ameba {
     }
 
     public execute(document: TextDocument | WorkspaceFolder, virtual: boolean = false): void {
-        // This check is to see if `document` conforms to the `TextDocument` or `WorkspaceFolder` interfaces
-        const isDocument = ('languageId' in document);
-        if (!isDocument) virtual = false;
+        if (!this.isTextDocument(document)) virtual = false;
 
-        if (isDocument) {
+        if (this.isTextDocument(document)) {
             if (!isValidCrystalDocument(document)) return;
             if (isDocumentVirtual(document) && !virtual) return;
         }
@@ -46,7 +44,7 @@ export class Ameba {
         const configFile = path.join(dir, this.config.configFileName);
         if (existsSync(configFile)) args.push('--config', configFile);
 
-        if (isDocument) {
+        if (this.isTextDocument(document)) {
             if (!virtual) {
                 args.push(document.fileName)
             } else {
@@ -72,7 +70,7 @@ export class Ameba {
                 outputChannel.appendLine(`$ ${args.join(' ')}`)
                 const proc = spawn(args[0], args.slice(1), { cwd: dir });
 
-                if (virtual && isDocument) {
+                if (virtual && this.isTextDocument(document)) {
                     const documentText: string = document.getText();
                     proc.stdin.write(documentText)
                     proc.stdin.end();
@@ -229,5 +227,9 @@ export class Ameba {
             this.taskQueue.clear();
             this.diag.clear();
         }
+    }
+
+    isTextDocument(document: TextDocument | WorkspaceFolder): document is TextDocument {
+        return (document as TextDocument).languageId !== undefined;
     }
 }

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -31,10 +31,11 @@ export class Ameba {
     }
 
     public execute(document: TextDocument | WorkspaceFolder, virtual: boolean = false): void {
-        const isWorkspace = !('languageId' in document);
-        if (isWorkspace) virtual = false;
+        // This check is to see if `document` conforms to the `TextDocument` or `WorkspaceFolder` interfaces
+        const isDocument = ('languageId' in document);
+        if (!isDocument) virtual = false;
 
-        if (!isWorkspace) {
+        if (isDocument) {
             if (!isValidCrystalDocument(document)) return;
             if (isDocumentVirtual(document) && !virtual) return;
         }
@@ -45,7 +46,7 @@ export class Ameba {
         const configFile = path.join(dir, this.config.configFileName);
         if (existsSync(configFile)) args.push('--config', configFile);
 
-        if (!isWorkspace) {
+        if (isDocument) {
             if (!virtual) {
                 args.push(document.fileName)
             } else {
@@ -71,7 +72,7 @@ export class Ameba {
                 outputChannel.appendLine(`$ ${args.join(' ')}`)
                 const proc = spawn(args[0], args.slice(1), { cwd: dir });
 
-                if (virtual && !isWorkspace) {
+                if (virtual && isDocument) {
                     const documentText: string = document.getText();
                     proc.stdin.write(documentText)
                     proc.stdin.end();

--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -31,9 +31,9 @@ export class Ameba {
     }
 
     public execute(document: TextDocument | WorkspaceFolder, virtual: boolean = false): void {
-        if (!this.isTextDocument(document)) virtual = false;
-
-        if (this.isTextDocument(document)) {
+        if (!this.isTextDocument(document)) {
+            virtual = false;
+       } else {
             if (!isValidCrystalDocument(document)) return;
             if (isDocumentVirtual(document) && !virtual) return;
         }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,12 +10,18 @@ export interface AmebaConfig {
     command: string;
     configFileName: string;
     trigger: LintTrigger;
+    scope: LintScope;
 }
 
 export enum LintTrigger {
     None = "none",
     Save = "save",
     Type = "type"
+}
+
+export enum LintScope {
+    File = "file",
+    Workspace = "workspace"
 }
 
 export function getConfig(): AmebaConfig {
@@ -34,6 +40,7 @@ export function getConfig(): AmebaConfig {
     const workspaceConfig = workspace.getConfiguration('crystal-ameba');
     const currentVersion = execSync(`"${command}" --version`).toString();
 
+    const scope = workspaceConfig.get<LintScope>("lint-scope", LintScope.File);
     let trigger = workspaceConfig.get<LintTrigger>("lint-trigger", LintTrigger.Type);
 
     if (!semver.satisfies(currentVersion, ">=1.6.4") && trigger == LintTrigger.Type) {
@@ -43,6 +50,7 @@ export function getConfig(): AmebaConfig {
     return {
         command,
         configFileName: '.ameba.yml',
-        trigger: trigger
+        trigger: trigger,
+        scope: scope
     };
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,11 +141,9 @@ export function activate(context: ExtensionContext) {
 
     workspace.onDidCloseTextDocument(doc => {
         if (!ameba || !isValidCrystalDocument(doc)) return;
-        let shouldClear = false;
+        let shouldClear = true;
 
-        if (ameba.config.scope == LintScope.Workspace) {
-            shouldClear = true;
-        } else if (workspace.workspaceFolders) {
+        if (workspace.workspaceFolders) {
             shouldClear = !workspace.getWorkspaceFolder(doc.uri);
         }
 


### PR DESCRIPTION
This tells ameba to either run only on open files or the entire workspace, and is useful for those who want to know what's happening across all files in the workspace instead of open ones.

This also adds a command for linting all files in the workspace, and fixes some minor bugs regarding handling virtual / untitled documents.