### PR TITLE
Fix for Useless conditional

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,7 +52,6 @@ export function activate(context: ExtensionContext) {
     context.subscriptions.push(
         commands.registerCommand('crystal.ameba.lint-workspace', () => {
             if (ameba) {
-                if (!ameba) return;
                 outputChannel.appendLine('[Lint] Running ameba on current workspace')
                 executeAmebaOnWorkspace(ameba)
             } else {


### PR DESCRIPTION
In general, to fix a condition that always evaluates to the same boolean value, you either remove the unreachable branch or refactor the logic so that the condition can actually vary as intended. Here, the inner `if (!ameba) return;` is inside an `if (ameba)` block, so it can never be true and serves no purpose.

The best fix without changing functionality is to delete the inner `if (!ameba) return;` on line 55, leaving the outer `if (ameba)` as the sole guard before running `executeAmebaOnWorkspace(ameba)`. No additional imports, methods, or definitions are needed. The behavior remains identical: if `ameba` is non-null, the workspace lint runs; otherwise, the "enable" prompt is shown.

Specifically:
- In `src/extension.ts`, within the `commands.registerCommand('crystal.ameba.lint-workspace', ...)` callback, remove the line `if (!ameba) return;`.
- Keep the rest of the logic and logging unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._