### PR TITLE
Fix: use `Uri.file` instead of `Uri.parse`

### DIFF
--- a/src/ameba.ts
+++ b/src/ameba.ts
@@ -180,9 +180,9 @@ export class Ameba {
                         if (virtual) {
                             diagnosticUri = document.uri;
                         } else if (path.isAbsolute(source.path)) {
-                            diagnosticUri = Uri.parse(source.path)
+                            diagnosticUri = Uri.file(source.path)
                         } else {
-                            diagnosticUri = Uri.parse(path.join(dir, source.path));
+                            diagnosticUri = Uri.file(path.join(dir, source.path));
                         }
 
                         let logPath: string

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -206,7 +206,7 @@ export function noWorkspaceFolder(uri: Uri): WorkspaceFolder {
     }
 
     return {
-        uri: Uri.parse(path.dirname(uri.fsPath)),
+        uri: Uri.file(path.dirname(uri.fsPath)),
         name: path.basename(path.dirname(uri.fsPath)),
         index: -1
     }


### PR DESCRIPTION
Using `Uri.parse()` for file paths can fail on Windows due to backslashes.